### PR TITLE
Add unveil interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Docs](https://img.shields.io/badge/docs-available-brightgreen.svg)](https://chris-huxtable.github.io/pledge.cr/)
 [![GitHub release](https://img.shields.io/github/release/chris-huxtable/pledge.cr.svg)](https://github.com/chris-huxtable/pledge.cr/releases)
 
-Adds `pledge(2)` to crystal.
+Adds `pledge(2)` and `unveil(2)` to crystal.
 
 ## Installation
 
@@ -20,7 +20,7 @@ dependencies:
 require "pledge"
 ```
 
-Partial `syscall` restrictions:
+Partial `syscall` restrictions with `pledge`:
 ``` crystal
 Process.pledge(:stdio, :rpath, :wpath, :flock)
 Process.pledge("stdio", "rpath")
@@ -31,7 +31,23 @@ Full restrictions:
 Process.pledge()
 ```
 
-More information and a list of 'promises' is available in the OpenBSD [man pages](http://man.openbsd.org/pledge).
+Filesystem restrictions with `unveil`:
+
+``` crystal
+Process.unveil({"/home/foo/bar" => "r", "/home/foo/bar/data" => "rwc"})
+```
+
+Remove further unveiling:
+
+``` crystal
+Process.unveil
+```
+
+More information and a list of pledge 'promises' are available in the OpenBSD
+man pages for
+[pledge(2)](http://man.openbsd.org/pledge)
+and
+[unveil(2)](http://man.openbsd.org/unveil).
 
 ## Contributing
 

--- a/spec/pledge_spec.cr
+++ b/spec/pledge_spec.cr
@@ -1,0 +1,43 @@
+# Copyright (c) 2021 joshua stein <jcs@jcs.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+require "./spec_helper"
+
+describe "pledge" do
+  it "pledges" do
+    reader, writer = IO.pipe
+
+    child = Process.fork do
+      Process.pledge("stdio")
+
+      File.open("/etc/passwd")
+      writer.puts "shouldn't get here"
+    end
+
+    child.wait.exit_status.should eq LibC::SIGABRT
+  end
+
+  it "catches bad pledges" do
+    reader, writer = IO.pipe
+
+    child = Process.fork do
+      Process.pledge("stdonk")
+    rescue e : Process::PledgeError
+      writer.puts e.class
+    end
+
+    child.wait
+    reader.gets.should eq "Process::PledgeError"
+  end
+end

--- a/spec/unveil_spec.cr
+++ b/spec/unveil_spec.cr
@@ -1,0 +1,54 @@
+# Copyright (c) 2021 joshua stein <jcs@jcs.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+require "./spec_helper"
+
+describe "unveil" do
+  it "veils the filesystem" do
+    reader, writer = IO.pipe
+
+    child = Process.fork do
+      Process.unveil({ "/etc/motd" => "r" })
+      File.open("/etc/motd").class.should eq File
+
+      begin
+        File.open("/etc/passwd").should eq nil
+        exit 1
+      rescue File::Error
+        exit 0
+      end
+    end
+
+    child.wait.exit_status.should eq 0
+  end
+
+  it "prevents further unveiling after final unveil" do
+    reader, writer = IO.pipe
+
+    child = Process.fork do
+      Process.unveil({ "/etc/motd" => "r" })
+      Process.unveil
+
+      begin
+        Process.unveil({ "/etc/passwd" => "r" })
+      rescue e : Process::UnveilError
+        exit 0
+      end
+
+      exit 1
+    end
+
+    child.wait.exit_status.should eq 0
+  end
+end

--- a/src/pledge/lib_c/unistd.cr
+++ b/src/pledge/lib_c/unistd.cr
@@ -15,5 +15,6 @@
 {% skip_file() if !flag?(:openbsd) %}
 
 lib LibC
-	fun pledge(promises : Char*, execpromises : Char*) : Int
+  fun pledge(promises : Char*, execpromises : Char*) : Int
+  fun unveil(path : Char*, permissions : Char*) : Int
 end

--- a/src/pledge/process+pledge.cr
+++ b/src/pledge/process+pledge.cr
@@ -15,48 +15,47 @@
 require "./lib_c/unistd"
 
 class Process
+  # The current process is forced into a restricted-service operating mode. A
+  # few subsets are available, roughly described as computation, memory
+  # management, read-write operations on file descriptors, opening of files,
+  # networking. In general, these modes were selected by studying the operation
+  # of many programs using libc and other such interfaces, and setting promises
+  # or execpromises.
+  #
+  # A process which attempts a restricted operation is killed with an
+  # uncatchable SIGABRT.
+  #
+  # More information is available in the OpenBSD [man pages](http://man.openbsd.org/pledge).
+  #
+  # To restrict a process:
+  # ```
+  # Process.pledge(:stdio, :rpath, :wpath, :flock)
+  # Process.pledge(["stdio", "rpath"], ["/some/exec/promise"])
+  # ```
+  #
+  # To completely restrict a process:
+  # ```
+  # Process.pledge
+  # ```
+  def self.pledge(promises : Array(String | Symbol) = [""] of String | Symbol, execpromises : Array(String)? = nil)
+    {% if flag?(:openbsd) %}
+      promises = promises.join(' ')
+      execpromises = execpromises.join(' ') if execpromises
+      if (LibC.pledge(promises, execpromises) != 0)
+        case (Errno.value)
+        when Errno::EFAULT then raise Errno.new("pledge: Promises or execpromises points outside the process's allocated address space")
+        when Errno::EINVAL then raise Errno.new("pledge: Promises is malformed or contains invalid keywords")
+        when Errno::EPERM  then raise Errno.new("pledge: This process is attempting to increase permissions")
+        else                    raise Errno.new("pledge")
+        end
+      end
+    {% else %}
+      raise NotImplementedError.new("Process.pledge")
+    {% end %}
+  end
 
-	# The current process is forced into a restricted-service operating mode. A
-	# few subsets are available, roughly described as computation, memory
-	# management, read-write operations on file descriptors, opening of files,
-	# networking. In general, these modes were selected by studying the operation
-	# of many programs using libc and other such interfaces, and setting promises
-	# or execpromises.
-	#
-	# A process which attempts a restricted operation is killed with an
-	# uncatchable SIGABRT.
-	#
-	# More information is available in the OpenBSD [man pages](http://man.openbsd.org/pledge).
-	#
-	# To restrict a process:
-	# ```
-	# Process.pledge(:stdio, :rpath, :wpath, :flock)
-	# Process.pledge(["stdio", "rpath"], ["/some/exec/promise"])
-	# ```
-	#
-	# To completely restrict a process:
-	# ```
-	# Process.pledge()
-	# ```
-	def self.pledge(promises : Array(String|Symbol) = [""] of String|Symbol, execpromises : Array(String)? = nil)
-		{% if flag?(:openbsd) %}
-			promises = promises.join(' ')
-			execpromises = execpromises.join(' ') if execpromises
-			if ( LibC.pledge(promises, execpromises) != 0 )
-				case ( Errno.value )
-					when Errno::EFAULT then raise Errno.new("pledge: Promises or execpromises points outside the process's allocated address space")
-					when Errno::EINVAL then raise Errno.new("pledge: Promises is malformed or contains invalid keywords")
-					when Errno::EPERM  then raise Errno.new("pledge: This process is attempting to increase permissions")
-					else raise Errno.new("pledge")
-				end
-			end
-		{% else %}
-			raise NotImplementedError.new("Process.pledge")
-		{% end %}
-	end
-
-	# ditto
-	def self.pledge(*promises : String|Symbol)
-		pledge(promises.to_a)
-	end
+  # ditto
+  def self.pledge(*promises : String | Symbol)
+    pledge(promises.to_a)
+  end
 end

--- a/src/pledge/process+unveil.cr
+++ b/src/pledge/process+unveil.cr
@@ -1,0 +1,78 @@
+# Copyright (c) 2021 joshua stein <jcs@jcs.org>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+require "./lib_c/unistd"
+
+class Process
+  class UnveilError < Exception
+    include SystemError
+  end
+
+  # The first call to unveil that specifies a path removes visibility of the
+  # entire filesystem from all other filesystem-related system calls (such as
+  # open(2), chmod(2) and rename(2)), except for the specified path and
+  # permissions.
+  #
+  # The unveil system call remains capable of traversing to any path in the
+  # filesystem, so additional calls can set permissions at other points in the
+  # filesystem hierarchy.
+  #
+  # After establishing a collection of path and permissions rules, future calls
+  # to unveil can be disabled by calling Process.unveil.
+  #
+  # More information is available in the OpenBSD [man pages](http://man.openbsd.org/unveil).
+  #
+  # To restrict a process's view of the filesystem:
+  # ```
+  # Process.unveil({"/home/foo/bar" => "r", "/home/foo/bar/data" => "rwc"})
+  # Process.unveil
+  # ```
+  def self.unveil(paths : Hash(String, String))
+    {% if flag?(:openbsd) %}
+      if paths.size == 0
+        if LibC.unveil(nil, nil) != 0
+          case Errno.value
+          when Errno::EPERM
+            raise UnveilError.new("unveil already locked")
+          else
+            raise UnveilError.from_errno("unveil")
+          end
+        end
+      else
+        paths.each do |path, permission|
+          if LibC.unveil(path, permission) != 0
+            case Errno.value
+            when Errno::E2BIG
+              raise UnveilError.new("unveiled path list too large")
+            when Errno::ENOENT
+              raise UnveilError.new("directory in #{path} does not exist")
+            when Errno::EINVAL
+              raise UnveilError.new("invalid permissions #{permission.inspect}")
+            when Errno::EPERM
+              raise UnveilError.new("attempt to increase permissions, path not accessible, or already locked")
+            else
+              raise UnveilError.from_errno("unveil")
+            end
+          end
+        end
+      end
+    {% else %}
+      raise NotImplementedError.new("Process.unveil")
+    {% end %}
+  end
+
+  def self.unveil
+    unveil({} of String => String)
+  end
+end


### PR DESCRIPTION
`unveil` usually goes hand-in-hand with `pledge` so I didn't want to make a new module just for `unveil` support.  This also matches the functionality of the [Ruby pledge module](https://github.com/jeremyevans/ruby-pledge).